### PR TITLE
Fixed emitter erroring

### DIFF
--- a/WAC Aircraft/lua/entities/wac_hc_base/cl_init.lua
+++ b/WAC Aircraft/lua/entities/wac_hc_base/cl_init.lua
@@ -180,6 +180,7 @@ function ENT:OnRemove()
 	for _, t in pairs(self.weaponAttachments) do
 		t.model:Remove()
 	end
+	self.Emitter:Finish()
 end
 
 
@@ -555,7 +556,7 @@ function ENT:Draw()
 					particle:SetEndSize(20*self.Scale)
 					particle:SetColor(255,255,255)
 					particle:SetRoll(math.Rand(-50,50))
-					self.Emitter:Finish()
+					//self.Emitter:Finish()
 				end
 			else
 				local particle = self.Emitter:Add("sprites/heatwave",self:LocalToWorld(self.SmokePos))
@@ -567,7 +568,7 @@ function ENT:Draw()
 				particle:SetEndSize(20*self.Scale)
 				particle:SetColor(255,255,255)
 				particle:SetRoll(math.Rand(-50,50))
-				self.Emitter:Finish()
+				//self.Emitter:Finish()
 			end
 			self.lastHeatDrawn = CurTime()
 		end


### PR DESCRIPTION
Caused by Emitter:Finish being fixed in GMod update, but removing the emitter too early caused it to error. Emitter now removed on aircraft removal.
