### PR TITLE
Fixed VCMod incompatibility

### DIFF
--- a/WAC Base/lua/entities/wac_seat_connector/init.lua
+++ b/WAC Base/lua/entities/wac_seat_connector/init.lua
@@ -76,6 +76,9 @@ function ENT:switchSeat(p, int)
 	local oldang = p:GetAimVector():Angle()
 	oldang.y = oldang.y+90
 	p:ExitVehicle()
+	if VCMod1 then
+		p.VC_CanEnterTime = CurTime()
+	end
 	p:EnterVehicle(self.seats[int])
 	--p:SnapEyeAngles(self.seats[int]:GetAngles())
 	self:updateSeats()


### PR DESCRIPTION
This fixes #110. VCMod would throw you out when you tried to change seats and this was really annoying, sometimes damaging aircraft even.