### PR TITLE
Fix for gmod update 2016-10-10

### DIFF
--- a/WAC Aircraft/lua/entities/wac_hc_base/init.lua
+++ b/WAC Aircraft/lua/entities/wac_hc_base/init.lua
@@ -815,8 +815,6 @@ function ENT:PhysicsUpdate(ph)
 				else
 					self.backRotor.Phys:AddAngleVelocity(Vector(0,self.rotorRpm*300*self.BackRotor.dir-self.backRotor.Phys:GetAngleVelocity().y/10,0)*phm)
 				end
-
-				self.backRotor.Phys:AddAngleVelocity(self.backRotor.Phys:GetAngleVelocity() * rotorBrake / 10)
 			else
 				ph:AddAngleVelocity((Vector(0,0,0-self.rotorRpm*self.TopRotor.dir/2))*phm)
 				ph:AddAngleVelocity(VectorRand()*self.rotorRpm*mind*phm)


### PR DESCRIPTION
`rotorBrake` is nil and gmod update now makes `Vector * nil` error instead of returning a zeroed vector. This line did nothing anyway, would have just added 0 angular velocity.