### PR TITLE
Configurable FOV (WAC Aircraft)

### DIFF
--- a/wac aircraft/lua/autorun/client/wac_aircraft.lua
+++ b/wac aircraft/lua/autorun/client/wac_aircraft.lua
@@ -229,7 +229,7 @@ wac.addMenuPanel(wac.menu.tab, wac.menu.category, wac.menu.aircraft, function(pa
 	panel:CheckBox("Dynamic View Angle","wac_cl_air_smoothview")
 	
 	panel:CheckBox("Dynamic View Position","wac_cl_air_shakeview")
-	
+
 	panel:CheckBox("Override Field of View", "wac_cl_air_overridefov");
 
 	panel:CheckBox("Use Mouse","wac_cl_air_mouse")

--- a/wac aircraft/lua/autorun/client/wac_aircraft.lua
+++ b/wac aircraft/lua/autorun/client/wac_aircraft.lua
@@ -9,6 +9,8 @@ CreateClientConVar("wac_cl_air_mouse_invert_pitch", 0, true, true)
 CreateClientConVar("wac_cl_air_mouse_invert_yawroll", 0, true, true)
 CreateClientConVar("wac_cl_air_smoothview", 1, true, true)
 CreateClientConVar("wac_cl_air_shakeview", 1, true, true)
+CreateClientConVar("wac_cl_air_overridefov", 1, true, true)
+CreateClientConVar("wac_cl_air_fov", 75, true, true)
 CreateClientConVar("wac_cl_air_smoothkeyboard", 1, true, true)
 CreateClientConVar("wac_cl_air_arcade", 0, true, true)
 CreateClientConVar("wac_cl_air_volume", 1, true, true)
@@ -75,7 +77,10 @@ wac.hook("CalcView", "wac_air_calcview", function(p, pos, ang, fov)
 	
 	local i = p:GetNWInt("wac_passenger_id")
 	if p.wac.air.vehicle and GetViewEntity() == p and aircraft.Seats then
-		return aircraft:viewCalc((i==0 and 1 or i), p, pos, ang, 75)
+		if p:GetInfoNum( "wac_cl_air_overridefov", 1 ) == 1 then
+			fov = p:GetInfoNum( "wac_cl_air_fov", 75 );
+		end
+		return aircraft:viewCalc((i==0 and 1 or i), p, pos, ang, fov)
 	end
 
 end)
@@ -218,12 +223,14 @@ wac.addMenuPanel(wac.menu.tab, wac.menu.category, wac.menu.aircraft, function(pa
 		Max=1,
 		Command="wac_cl_air_volume",
 	})
-
+	
 	panel:CheckBox("Arcade Mode","wac_cl_air_arcade")
 	
 	panel:CheckBox("Dynamic View Angle","wac_cl_air_smoothview")
 	
 	panel:CheckBox("Dynamic View Position","wac_cl_air_shakeview")
+	
+	panel:CheckBox("Override Field of View", "wac_cl_air_overridefov");
 
 	panel:CheckBox("Use Mouse","wac_cl_air_mouse")
 	if info["wac_cl_air_mouse"]=="1" then
@@ -237,6 +244,16 @@ wac.addMenuPanel(wac.menu.tab, wac.menu.category, wac.menu.aircraft, function(pa
 			Min = 0.5,
 			Max = 1.9,
 			Command = "wac_cl_air_sensitivity",
+		})
+	end
+	
+	if info["wac_cl_air_overridefov"]=="1" then
+		panel:AddControl("Slider", {
+			Label="Field of View",
+			Type="integer",
+			Min=60,
+			Max=140,
+			Command="wac_cl_air_fov",
 		})
 	end
 	
@@ -310,6 +327,7 @@ wac.addMenuPanel(wac.menu.tab, wac.menu.category, wac.menu.aircraft, function(pa
 	end
 end,
 	"wac_cl_air_mouse",
-	"wac_cl_air_showdevhelp"
+	"wac_cl_air_showdevhelp",
+	"wac_cl_air_overridefov"
 )
 

--- a/wac aircraft/lua/autorun/client/wac_aircraft.lua
+++ b/wac aircraft/lua/autorun/client/wac_aircraft.lua
@@ -223,7 +223,7 @@ wac.addMenuPanel(wac.menu.tab, wac.menu.category, wac.menu.aircraft, function(pa
 		Max=1,
 		Command="wac_cl_air_volume",
 	})
-	
+
 	panel:CheckBox("Arcade Mode","wac_cl_air_arcade")
 	
 	panel:CheckBox("Dynamic View Angle","wac_cl_air_smoothview")
@@ -256,7 +256,7 @@ wac.addMenuPanel(wac.menu.tab, wac.menu.category, wac.menu.aircraft, function(pa
 			Command="wac_cl_air_fov",
 		})
 	end
-	
+
 	panel:AddControl("Button", {
 		Label = "Joystick Configuration",
 		Command = "joyconfig"


### PR DESCRIPTION
By default the player's Field of View is changed to a constant 75 when inside the aircraft. Which makes sure you can always read HUD, but is a bit of a pain for me, as I usually play on a 100.

I added a checkbox to WAC Aircraft options menu, labeled `Override Field of View`, which is checked by default. The value to which the FOV is overridden can be changed via newly added `Field of View` slider. ('75' by default, and hidden if `Override Field of View` is unchecked.) If `Override Field of View` is unchecked, the usual player FOV is used.